### PR TITLE
Implement JSON root endpoint and tests (#12)

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -31,14 +31,19 @@ from service.utils import PromotionType
 ######################################################################
 # GET INDEX
 ######################################################################
-@app.route("/")
+@app.route("/", methods=["GET"])
 def index():
     """Root URL response"""
     return (
-        "Reminder: return some useful information in json format about the service here",
+        jsonify(
+            name="Promotions REST API",
+            version="1.0.0",
+            resources={
+                "promotions": url_for("list_promotions", _external=False)
+            },
+        ),
         status.HTTP_200_OK,
     )
-
 
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -72,10 +72,32 @@ class TestPromotionService(TestCase):
     #  P L A C E   T E S T   C A S E S   H E R E
     ######################################################################
 
+    # def test_index(self):
+        # """It should call the home page"""
+        # resp = self.client.get("/")
+        # self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
     def test_index(self):
-        """It should call the home page"""
+        """Test the root URL"""
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(resp.is_json)
+
+        data = resp.get_json()
+        self.assertIn("name", data)
+        self.assertIn("version", data)
+        self.assertIn("resources", data)
+        self.assertIn("promotions", data["resources"])
+        
+    def test_404_returns_json(self):
+        resp = self.client.get("/not_found")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(resp.is_json)
+    
+    def test_405_returns_json(self):
+        resp = self.client.put("/promotions")
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertTrue(resp.is_json)
 
     ############################################################
     # Utility function to bulk create pets


### PR DESCRIPTION
Implemented GET / to return JSON service information.

Changes:
- Root endpoint now returns JSON with name, version, and resources
- Added tests for:
  - GET /
  - 404 JSON response
  - 405 JSON response

All tests pass and coverage meets the 95% requirement.
Closes #12