### PR TITLE
Add image build task to pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -4,51 +4,29 @@ metadata:
   name: promotion-cd-pipeline
 spec:
   params:
-    - default: 'https://github.com/CSCI-GA-2820-SP26-003/promotions.git'
+    - name: GIT_REPO
+      type: string
       description: The URL to the git repo
-      name: GIT_REPO
+      default: 'https://github.com/CSCI-GA-2820-SP26-003/promotions.git'
+    - name: GIT_REF
       type: string
-    - default: master
       description: The reference (branch or ref)
-      name: GIT_REF
-      type: string
+      default: master
     - name: base-url
       type: string
       default: http://promotions:8080
+    - name: build-image
+      type: string
+      description: The fully qualified image name to build and push
+      default: image-registry.openshift-image-registry.svc:5000/curieyoon-dev/promotions:latest
+
+  workspaces:
+    - name: pipeline-workspace
+
   tasks:
     - name: git-clone
-      params:
-        - name: CRT_FILENAME
-          value: ca-bundle.crt
-        - name: HTTP_PROXY
-          value: ''
-        - name: HTTPS_PROXY
-          value: ''
-        - name: NO_PROXY
-          value: ''
-        - name: SUBDIRECTORY
-          value: ''
-        - name: USER_HOME
-          value: /home/git
-        - name: DELETE_EXISTING
-          value: 'true'
-        - name: VERBOSE
-          value: 'false'
-        - name: SSL_VERIFY
-          value: 'true'
-        - name: URL
-          value: $(params.GIT_REPO)
-        - name: REVISION
-          value: $(params.GIT_REF)
-        - name: REFSPEC
-          value: ''
-        - name: SUBMODULES
-          value: 'true'
-        - name: DEPTH
-          value: '1'
-        - name: SPARSE_CHECKOUT_DIRECTORIES
-          value: ''
       taskRef:
+        resolver: cluster
         params:
           - name: kind
             value: task
@@ -56,13 +34,70 @@ spec:
             value: git-clone
           - name: namespace
             value: openshift-pipelines
-        resolver: cluster
+      params:
+        - name: URL
+          value: $(params.GIT_REPO)
+        - name: REVISION
+          value: $(params.GIT_REF)
+        - name: SUBMODULES
+          value: 'true'
+        - name: DEPTH
+          value: '1'
+        - name: SSL_VERIFY
+          value: 'true'
+        - name: DELETE_EXISTING
+          value: 'true'
+        - name: VERBOSE
+          value: 'false'
+        - name: USER_HOME
+          value: /home/git
+        - name: CRT_FILENAME
+          value: ca-bundle.crt
       workspaces:
         - name: output
           workspace: pipeline-workspace
+
+    - name: lint
+      taskRef:
+        name: pylint
+        kind: Task
+      runAfter:
+        - git-clone
+      params:
+        - name: path
+          value: service
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: tests
+      taskRef:
+        name: pytest-env
+        kind: Task
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: build
+      taskRef:
+        name: buildah
+        kind: Task
+      runAfter:
+        - tests
+        - lint
+      params:
+        - name: IMAGE
+          value: "$(params.build-image)"
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
     - name: behave-test
       taskRef:
         name: behave
+        kind: Task
       runAfter:
         - git-clone
       params:
@@ -71,5 +106,3 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
-  workspaces:
-    - name: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -62,7 +62,7 @@ spec:
         python -m pip install pylint
 
         echo "***** Running Linting *****"
-        pylint $@ "$(params.path)"
+        pylint --fail-under=9.0 $@ "$(params.path)"
       args:
         - "$(params.args)"
 
@@ -296,3 +296,85 @@ spec:
 
         echo "***** Running Tests *****"
         behave
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+  labels:
+    app.kubernetes.io/version: "0.6"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "buildah"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    Buildah builds source into a container image using Project Atomic's
+    Buildah, then pushes it to a container registry.
+  params:
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+    - name: BUILDER_IMAGE
+      description: The location of the buildah builder image.
+      default: quay.io/buildah/stable:v1.23.3
+    - name: STORAGE_DRIVER
+      description: Set buildah storage driver
+      default: vfs
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+    - name: CONTEXT
+      description: Path to the directory to use as context.
+      default: .
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint
+      default: "true"
+    - name: FORMAT
+      description: The format of the built container, oci or docker
+      default: "oci"
+    - name: BUILD_EXTRA_ARGS
+      description: Extra parameters passed for the build command
+      default: ""
+    - name: PUSH_EXTRA_ARGS
+      description: Extra parameters passed for the push command
+      default: ""
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built.
+    - name: IMAGE_URL
+      description: Image repository where the built image was pushed to.
+  workspaces:
+    - name: source
+  steps:
+    - name: build-and-push
+      image: $(params.BUILDER_IMAGE)
+      workingDir: $(workspaces.source.path)
+      script: |
+        buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+          $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+          --tls-verify=$(params.TLSVERIFY) --no-cache \
+          -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+
+        buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+          $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee $(results.IMAGE_DIGEST.path)
+        echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
+      volumeMounts:
+        - name: varlibcontainers
+          mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
+  volumes:
+    - name: varlibcontainers
+      emptyDir: {}


### PR DESCRIPTION
The build task uses the Tekton catalog buildah task (inlined into .tekton/tasks.yaml) and is gated on lint and tests via runAfter