### PR TITLE
Add comment for lint step in CD pipeline (#94)

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -7,7 +7,7 @@ spec:
     - name: GIT_REPO
       type: string
       description: The URL to the git repo
-      default: 'https://github.com/CSCI-GA-2820-SP26-003/promotions.git'
+      default: "https://github.com/CSCI-GA-2820-SP26-003/promotions.git"
     - name: GIT_REF
       type: string
       description: The reference (branch or ref)
@@ -40,15 +40,15 @@ spec:
         - name: REVISION
           value: $(params.GIT_REF)
         - name: SUBMODULES
-          value: 'true'
+          value: "true"
         - name: DEPTH
-          value: '1'
+          value: "1"
         - name: SSL_VERIFY
-          value: 'true'
+          value: "true"
         - name: DELETE_EXISTING
-          value: 'true'
+          value: "true"
         - name: VERBOSE
-          value: 'false'
+          value: "false"
         - name: USER_HOME
           value: /home/git
         - name: CRT_FILENAME
@@ -57,6 +57,7 @@ spec:
         - name: output
           workspace: pipeline-workspace
 
+    # Run lint (code quality check) after cloning the repository
     - name: lint
       taskRef:
         name: pylint


### PR DESCRIPTION
### Summary

* Verified that the lint step is already implemented in the CD pipeline using the existing `pylint` task
* Added a comment to clarify the purpose of the lint step in the pipeline

### Details

* The lint task runs after the `git-clone` step
* It performs code quality checks before the build step
* Ensures that the pipeline fails if lint errors are detected

### Result

* Improved readability and maintainability of the pipeline
* Confirmed correct integration of lint in the CD workflow