### PR TITLE
Add /api prefix to REST API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ tests/                     - test cases package
 | Method   | Endpoint                     | Description                    |
 | -------- | ---------------------------- | ------------------------------ |
 | `GET`    | `/`                          | Root |
-| `POST`   | `/promotions`                | Create a new promotion         |
-| `GET`    | `/promotions`                | List all promotions            |
-| `GET`    | `/promotions/<promotion_id>` | Retrieve a promotion by ID     |
-| `PUT`    | `/promotions/<promotion_id>` | Update a promotion by ID       |
-| `DELETE` | `/promotions/<promotion_id>` | Delete a promotion by ID       |
+| `POST`   | `/api/promotions`                | Create a new promotion         |
+| `GET`    | `/api/promotions`                | List all promotions            |
+| `GET`    | `/api/promotions/<promotion_id>` | Retrieve a promotion by ID     |
+| `PUT`    | `/api/promotions/<promotion_id>` | Update a promotion by ID       |
+| `DELETE` | `/api/promotions/<promotion_id>` | Delete a promotion by ID       |
 
 
 

--- a/features/steps/promotions_steps.py
+++ b/features/steps/promotions_steps.py
@@ -39,7 +39,7 @@ def step_impl(context):
     """Delete all Promotions and load new ones"""
 
     # Get a list all of the promotions
-    rest_endpoint = f"{context.base_url}/promotions"
+    rest_endpoint = f"{context.base_url}/api/promotions"
 
     context.resp = requests.get(rest_endpoint, timeout=WAIT_TIMEOUT)
 

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -41,7 +41,7 @@ def api_root():
     return {
         "name": "Promotions REST API Service",
         "version": "1.0",
-        "resources": {"promotions": "/promotions"},
+        "resources": {"promotions": "/api/promotions"},
     }, 200
 
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -58,8 +58,7 @@ promotion_model = promotions_ns.model(
 # Add Namespace
 ######################################################################
 api.add_namespace(root_ns, path="")
-api.add_namespace(promotions_ns, path="/promotions")
-
+api.add_namespace(promotions_ns, path="/api/promotions")
 
 ######################################################################
 # UI INDEX PAGE
@@ -203,8 +202,7 @@ class PromotionCollection(Resource):
         promotion.deserialize(data)
         promotion.create()
 
-        location_url = f"{request.host_url.rstrip('/')}/promotions/{promotion.id}"
-
+        location_url = f"{request.host_url.rstrip('/')}/api/promotions/{promotion.id}"
         return (
             promotion.serialize(),
             status.HTTP_201_CREATED,

--- a/service/static/js/ui_query_test.js
+++ b/service/static/js/ui_query_test.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = "/promotions";
+const API_BASE_URL = "/api/promotions";
 
 function getElementByIds(ids) {
     for (const id of ids) {

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -8,7 +8,7 @@ from wsgi import app
 from service.common import status
 
 
-BASE_URL = "/promotions"
+BASE_URL = "/api/promotions"
 
 
 class TestCoverageBoost(unittest.TestCase):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -33,7 +33,7 @@ from .factories import PromotionFactory
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
 )
-BASE_URL = "/promotions"
+BASE_URL = "/api/promotions"
 
 
 ######################################################################
@@ -139,7 +139,7 @@ class TestPromotionService(TestCase):
 
     def test_405_returns_json(self):
         """Test 405 returns"""
-        resp = self.client.put("/promotions")
+        resp = self.client.put("/api/promotions")
         self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertTrue(resp.is_json)
 


### PR DESCRIPTION
Update API to use `/api/promotions` prefix

* Updated routes and Location header
* Updated API root path
* Updated UI, tests, and BDD paths
* Verified endpoint works correctly