### PR TITLE
Add unit-test task to Tekton pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -71,9 +71,9 @@ spec:
         - name: source
           workspace: pipeline-workspace
 
-    - name: tests
+    - name: unit-test
       taskRef:
-        name: pytest-env
+        name: unit-test
         kind: Task
       runAfter:
         - git-clone
@@ -86,7 +86,7 @@ spec:
         name: buildah
         kind: Task
       runAfter:
-        - tests
+        - unit-test
         - lint
       params:
         - name: IMAGE

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -382,3 +382,36 @@ spec:
   volumes:
     - name: varlibcontainers
       emptyDir: {}
+      
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: unit-test
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Testing
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: python, pytest
+    tekton.dev/displayName: "unit tests"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  workspaces:
+    - name: source
+  description: >-
+    This task runs the unit tests with pytest.
+  steps:
+    - name: unit-test
+      image: quay.io/rofrano/python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/bash
+        set -e
+        export PATH=$PATH:$HOME/.local/bin:
+
+        echo "***** Installing dependencies *****"
+        python -m pip install --user -r requirements.txt
+
+        echo "***** Running Unit Tests *****"
+        pytest


### PR DESCRIPTION
- Added a new unit-test Tekton task to run pytest without database dependencies
- Avoided using pytest-env (which requires secrets and DB)
- Configured it to run in parallel with lint
- Updated build step to depend on both lint and unit-test
